### PR TITLE
JSW-53442: remove TLS pointer/deletion callback for correct thread

### DIFF
--- a/components/pthread/pthread_local_storage.c
+++ b/components/pthread/pthread_local_storage.c
@@ -147,7 +147,9 @@ static void pthread_cleanup_thread_specific_data_callback(int index, void *v_tls
     free(tls);
 }
 
-/* this function called from pthread_task_func for "early" cleanup of TLS in a pthread */
+/* this function called from pthread_task_func for "early" cleanup of TLS in a pthread
+   and from pthread_join/pthread_detach for cleanup of TLS after pthread exit
+*/
 void pthread_internal_local_storage_destructor_callback(TaskHandle_t handle)
 {
     void *tls = pvTaskGetThreadLocalStoragePointer(handle, PTHREAD_TLS_INDEX);
@@ -157,9 +159,9 @@ void pthread_internal_local_storage_destructor_callback(TaskHandle_t handle)
            calling it again...
         */
 #if !defined(CONFIG_FREERTOS_TLSP_DELETION_CALLBACKS)
-        vTaskSetThreadLocalStoragePointer(NULL, PTHREAD_TLS_INDEX, NULL);
+        vTaskSetThreadLocalStoragePointer(handle, PTHREAD_TLS_INDEX, NULL);
 #else
-        vTaskSetThreadLocalStoragePointerAndDelCallback(NULL,
+        vTaskSetThreadLocalStoragePointerAndDelCallback(handle,
                                                         PTHREAD_TLS_INDEX,
                                                         NULL,
                                                         NULL);


### PR DESCRIPTION
Originally, pthread_internal_local_storage_destructor_callback was only called from pthread_exit on the thread whose TLS is being destroyed.

In b3755b751ed42d98c933a919c744dc6455f5ee68, pthread_internal_local_storage_destructor_callback started being called from pthread_join and pthread_detach on a different thread (whichever one called one of those functions).

But pthread_internal_local_storage_destructor_callback is still calling vTaskSetThreadLocalStoragePointer and vTaskSetThreadLocalStoragePointerAndDelCallback with a NULL xTaskToSet argument, which causes those functions to set the TLS pointer and deletion callback for the current thread, not the thread whose TLS is being destroyed.

This commit makes pthread_internal_local_storage_destructor_callback call vTaskSetThreadLocalStoragePointer and vTaskSetThreadLocalStoragePointerAndDelCallback with the handle of the thread whose TLS is being destroyed.