### PR TITLE
JSW-59908: avoid hang on attempted close of non-opened device

### DIFF
--- a/components/usb/usb_host.c
+++ b/components/usb/usb_host.c
@@ -874,7 +874,6 @@ esp_err_t usb_host_device_close(usb_host_client_handle_t client_hdl, usb_device_
     HOST_ENTER_CRITICAL();
     uint8_t dev_addr;
     ESP_ERROR_CHECK(usbh_dev_get_addr(dev_hdl, &dev_addr));
-    HOST_CHECK_FROM_CRIT(_check_client_opened_device(client_obj, dev_addr), ESP_ERR_NOT_FOUND);
     if (!_check_client_opened_device(client_obj, dev_addr)) {
         // Client never opened this device
         ret = ESP_ERR_INVALID_STATE;


### PR DESCRIPTION
If you call *usb_host_device_close()* for a device that isn't open, the function exits early, without giving back the semaphore it took, which causes any other call that tries to take that semaphore to hang indefinitely.

Strangely, there's redundant handling of this case:

```c
    HOST_CHECK_FROM_CRIT(_check_client_opened_device(client_obj, dev_addr), ESP_ERR_NOT_FOUND);
    if (!_check_client_opened_device(client_obj, dev_addr)) {
        // Client never opened this device
        ret = ESP_ERR_INVALID_STATE;
        HOST_EXIT_CRITICAL();
        goto exit;
    }
…
exit:
    xSemaphoreGive(p_host_lib_obj->constant.mux_lock);
    return ret;
```

The first line is the one that exits early, as HOST_CHECK_FROM_CRIT returns its second parameter if its first parameter is false. The subsequent block handles the exact same failure, except that it ensures the semaphore is given back before exiting.

So this PR removes the first check.

This bug appears to have been present in the initial commit of the USB Host library to the ESP-IDF repo: https://github.com/espressif/esp-idf/commit/accbaee57ceca241ca117a53f486b7f79ed528b9

Of course, if you never try to close a non-opened device, then you won't encounter it!