### PR TITLE
JSW-64289: Restrict installed version of 'schema' Python package

### DIFF
--- a/tools/requirements/requirements.core.txt
+++ b/tools/requirements/requirements.core.txt
@@ -20,3 +20,6 @@ construct
 
 # gdb extensions dependencies
 freertos_gdb
+
+# Dependency restriction for ESP-IDF version v5.1.4-weber
+schema<=0.7.7


### PR DESCRIPTION
Restrict the version of the Python package `schema` to `0.7.7`.

The PR https://github.com/keleshev/schema/pull/330. which was released in `schema` version `0.7.8`, causes the following failure when the ESP-IDF is being installed:


```
TypeError: expected string or bytes-like object, got 're.Pattern'
```

<details><summary>Details</summary>
<p>

```
  -- Building ESP-IDF components for target esp32s3
  -- Checking Python dependencies...
  Python requirements are satisfied.
  Constraint file: /Users/kevin/src/juneoslite/.embuild/espressif/espidf.constraints.v5.1.txt
  Requirement files:
   - /Users/kevin/src/juneoslite/.embuild/espressif/esp-idf-3e3d654f8a323aea/v5.1.4-weber.1/tools/requirements/requirements.core.txt
  Python being checked: /Users/kevin/src/juneoslite/.embuild/espressif/python_env/idf5.1_py3.13_env/bin/python
  -- Configuring incomplete, errors occurred!
  See also "/Users/kevin/src/juneoslite/target/xtensa-esp32s3-espidf/debug/build/esp-idf-sys-4ed38d9f49ea6941/out/build/CMakeFiles/CMakeOutput.log".

  --- stderr
  Build configuration: BuildConfig {
      esp_idf_tools_install_dir: None,
      esp_idf_sdkconfig: None,
      esp_idf_sdkconfig_defaults: Some(
          [
              "A2/sdkconfig.defaults",
              "A2/sdkconfig-memfault",
          ],
      ),
      mcu: None,
      native: NativeConfig {
          esp_idf_version: Some(
              Tag(
                  "v5.1.4-weber.1",
              ),
          ),
          esp_idf_repository: Some(
              "https://github.com/junelife/esp-idf",
          ),
          esp_idf_cmake_generator: None,
          idf_path: None,
          extra_components: [
              ExtraComponent {
                  component_dirs: [
                      "../system/hal/drivers/storage/flash/w25q64jvssim/custom_driver",
                  ],
                  remote_component: None,
                  bindings_header: Some(
                      "bindings-w25q64jvssim.h",
                  ),
                  bindings_module: None,
                  manifest_dir: "/Users/kevin/src/juneoslite/A2/a2-root",
              },
              ExtraComponent {
                  component_dirs: [
                      "../../third_party/memfault-firmware-sdk/ports/esp_idf",
                  ],
                  remote_component: None,
                  bindings_header: Some(
                      "bindings-memfault.h",
                  ),
                  bindings_module: None,
                  manifest_dir: "/Users/kevin/src/juneoslite/A2/a2-root",
              },
              ExtraComponent {
                  component_dirs: [],
                  remote_component: Some(
                      RemoteComponent {
                          name: "espressif/esp_websocket_client",
                          version: "websocket-v1.2.2-dev-weber.2",
                          git: Some(
                              "https://github.com/junelife/esp-protocols.git",
                          ),
                          path: Some(
                              "components/esp_websocket_client",
                          ),
                          service_url: None,
                      },
                  ),
                  bindings_header: None,
                  bindings_module: None,
                  manifest_dir: "/Users/kevin/src/juneoslite/A2/a2-root",
              },
          ],
          esp_idf_components: None,
          esp_idf_component_manager: None,
      },
      esp_idf_sys_root_crate: Some(
          "a2-root",
      ),
  }
  Using managed esp-idf repository: RemoteSdk { repo_url: Some("https://github.com/junelife/esp-idf"), git_ref: Tag("v5.1.4-weber.1") }
  Using esp-idf v5.1.4 at '/Users/kevin/src/juneoslite/.embuild/espressif/esp-idf-3e3d654f8a323aea/v5.1.4-weber.1'
  CMake Error at /Users/kevin/src/juneoslite/.embuild/espressif/esp-idf-3e3d654f8a323aea/v5.1.4-weber.1/tools/cmake/build.cmake:541 (message):
    Traceback (most recent call last):

      File "<frozen runpy>", line 198, in _run_module_as_main
      File "<frozen runpy>", line 88, in _run_code
      File "/Users/kevin/src/juneoslite/.embuild/espressif/python_env/idf5.1_py3.13_env/lib/python3.13/site-packages/idf_component_manager/prepare_components/__main__.py", line 4, in <module>
        from .prepare import main
      File "/Users/kevin/src/juneoslite/.embuild/espressif/python_env/idf5.1_py3.13_env/lib/python3.13/site-packages/idf_component_manager/prepare_components/prepare.py", line 18, in <module>
        from ..core import ComponentManager
      File "/Users/kevin/src/juneoslite/.embuild/espressif/python_env/idf5.1_py3.13_env/lib/python3.13/site-packages/idf_component_manager/core.py", line 48, in <module>
        from idf_component_tools.manifest import (
        ...<5 lines>...
        )
      File "/Users/kevin/src/juneoslite/.embuild/espressif/python_env/idf5.1_py3.13_env/lib/python3.13/site-packages/idf_component_tools/manifest/__init__.py", line 11, in <module>
        from .manager import ManifestManager
      File "/Users/kevin/src/juneoslite/.embuild/espressif/python_env/idf5.1_py3.13_env/lib/python3.13/site-packages/idf_component_tools/manifest/manager.py", line 15, in <module>
        from .metadata import Metadata
      File "/Users/kevin/src/juneoslite/.embuild/espressif/python_env/idf5.1_py3.13_env/lib/python3.13/site-packages/idf_component_tools/manifest/metadata.py", line 9, in <module>
        from .schemas import serialize_list_of_list_of_strings
      File "/Users/kevin/src/juneoslite/.embuild/espressif/python_env/idf5.1_py3.13_env/lib/python3.13/site-packages/idf_component_tools/manifest/schemas.py", line 214, in <module>
        JSON_SCHEMA = manifest_json_schema()
      File "/Users/kevin/src/juneoslite/.embuild/espressif/python_env/idf5.1_py3.13_env/lib/python3.13/site-packages/idf_component_tools/manifest/schemas.py", line 167, in manifest_json_schema
        json_schema = MANIFEST_SCHEMA.json_schema(
            'idf-component-manager'
        )  # here id should be an url to use $ref in the future
      File "/Users/kevin/src/juneoslite/.embuild/espressif/python_env/idf5.1_py3.13_env/lib/python3.13/site-packages/schema/__init__.py", line 862, in json_schema
        return _json_schema(self, True)
      File "/Users/kevin/src/juneoslite/.embuild/espressif/python_env/idf5.1_py3.13_env/lib/python3.13/site-packages/schema/__init__.py", line 813, in _json_schema
        expanded_schema[key_name] = _json_schema(
                                    ~~~~~~~~~~~~^
            sub_schema,
            ^^^^^^^^^^^
        ...<2 lines>...
            description=_get_key_description(key),
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        )
        ^
      File "/Users/kevin/src/juneoslite/.embuild/espressif/python_env/idf5.1_py3.13_env/lib/python3.13/site-packages/schema/__init__.py", line 749, in _json_schema
        return_schema["pattern"] = re.sub(
                                   ~~~~~~^
            r"\(\?P<[a-z\d_]+>", "(", s.pattern_str
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        ).replace("/", r"\/")
        ^
      File "/opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/re/__init__.py", line 208, in sub
        return _compile(pattern, flags).sub(repl, string, count)
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^

    TypeError: expected string or bytes-like object, got 're.Pattern'

  Call Stack (most recent call first):
    /Users/kevin/src/juneoslite/.embuild/espressif/esp-idf-3e3d654f8a323aea/v5.1.4-weber.1/tools/cmake/project.cmake:604 (idf_build_process)
    CMakeLists.txt:28 (project)


  thread 'main' panicked at /Users/kevin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cmake-0.1.51/src/lib.rs:1100:5:

  command did not execute successfully, got: exit status: 1
```

</p>
</details> 